### PR TITLE
add badge to NuGet.org in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,6 @@ You can also read the doc pages locally under the [/docs](/docs) directory.
 
 #### Project
 
-* [NuGet Package](https://www.nuget.org/packages/Boa.Constrictor/)
+* [![Nuget](https://img.shields.io/nuget/v/Boa.Constrictor?label=NuGet%20Package)](https://www.nuget.org/packages/Boa.Constrictor/)
 * [License](LICENSE.md)
 * [Changelog](CHANGELOG.md)


### PR DESCRIPTION
For me these badges make it easier to find the link to the NuGet link.